### PR TITLE
Fixed issue with input file parameter ignored, extended limits of possible amount of iterations, optimized two step hill climbing.

### DIFF
--- a/anneal.hpp
+++ b/anneal.hpp
@@ -5,7 +5,7 @@ namespace marxan {
     typedef struct sanneal
     {
         long int Titns;
-        long int iterations;
+        long long iterations;
         long int Tlen;
         double Tinit;    /* Initial Temperature */
         double Tcool;    /* Cooling Factor */

--- a/connections.hpp
+++ b/connections.hpp
@@ -16,6 +16,18 @@ namespace marxan {
         double shortfall;
         double probability1D;
         double probability2D;
+        scost(): 
+            total(0.0), 
+            pus(0), 
+            connection(0.0), 
+            missing(0), 
+            penalty(0.0),  
+            cost(0.0),
+            threshpen(0.0),
+            shortfall(0.0),
+            probability1D(0.0),
+            probability2D(0.0)
+            {}
     } scost;
 
     /* Connectivity Structure. Fixed connectivity number.*/

--- a/hill_climbing.cpp
+++ b/hill_climbing.cpp
@@ -67,7 +67,7 @@ namespace marxan {
 
             }
 
-            void append(int i, int puno, const scost& reserve, const scost& change, const vector<int>& R)
+            void append(long long i, int puno, const scost& reserve, const scost& change, const vector<int>& R)
             {
                 iRowCounter++;
                 if (iRowCounter > iRowLimit)
@@ -75,9 +75,9 @@ namespace marxan {
 
                 if (iRowCounter == 1)
                 {
-                    fprintf(Rfp, "%i", i);
+                    fprintf(Rfp, "%lli", i);
 
-                    fprintf(ttfp, "%i,%f,%i,%f,%f,%f,%f\n"
+                    fprintf(ttfp, "%lli,%f,%i,%f,%f,%f,%f\n"
                                 , i, reserve.total
                                 , reserve.pus, reserve.cost, reserve.connection, reserve.penalty,
                                 change.total); // i,costthresh,pus,cost,connection,penalty
@@ -121,7 +121,7 @@ namespace marxan {
     void hill_climbing(int puno, int spno, const vector<spustuff>& pu, const vector<sconnections>& connections,
         vector<sspecies>& spec, const vector<spu>& SM, vector<spu_out>& SM_out, vector<int>& R, double cm,
         scost& reserve, double costthresh, double tpf1, double tpf2,
-        int clumptype,  int irun, int iterations, string savename, stringstream& logBuffer, rng_engine& rngEngine)
+        int clumptype,  int irun, long long iterations, string savename, stringstream& logBuffer, rng_engine& rngEngine)
     {
         scost change = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
         int puvalid = 0,  ipu = 0, imode, ichoice;
@@ -156,7 +156,7 @@ namespace marxan {
             logBuffer << "Hill climbing after array init\n";
             displayProgress2("  Main Hillclimbing Section.\n");
 
-            for(int itime = 1; itime <= iterations; )
+            for(long long itime = 1; itime <= iterations; )
             {
                 // shuffle iimp array
                 std::shuffle(iimparray.begin(), iimparray.end(), rngEngine);
@@ -196,7 +196,7 @@ namespace marxan {
     void hill_climbing_two_steps(int puno, int spno, const vector<spustuff>& pu, const vector<sconnections>& connections,
         vector<sspecies>& spec, const vector<spu>& SM, vector<spu_out>& SM_out, vector<int>& R, double cm,
         scost& reserve, double costthresh, double tpf1, double tpf2,
-        int clumptype,  int irun, int iterations, string savename, stringstream& logBuffer, rng_engine& rngEngine)
+        int clumptype,  int irun, long long iterations, string savename, stringstream& logBuffer, rng_engine& rngEngine)
     {
         int puvalid = 0,  ipu = 0;
         vector<int> iimparray;
@@ -231,7 +231,7 @@ namespace marxan {
             displayProgress2("  Main two step hillclimbing section.\n");
 
              
-            for(int itime = 1; itime <= iterations; )
+            for(long long itime = 1; itime <= iterations; )
             {
                 // shuffle iimp array
                 std::shuffle(iimparray.begin(), iimparray.end(), rngEngine);

--- a/hill_climbing.cpp
+++ b/hill_climbing.cpp
@@ -229,15 +229,13 @@ namespace marxan {
 
             logBuffer << "Two step hillclimbing after array init\n";
             displayProgress2("  Main two step hillclimbing section.\n");
-
-             
+            bool skip_add_two_units = true; 
             for(long long itime = 1; itime <= iterations; )
             {
                 // shuffle iimp array
                 std::shuffle(iimparray.begin(), iimparray.end(), rngEngine);
                 // ***** Doing the improvements ****  
                 bool was_change_per_total_loop = false;
-                bool skip_add_two_units = true; 
 
                 for (int i0 = 0; i0 < puvalid && itime <= iterations; i0++)
                 {

--- a/hill_climbing.hpp
+++ b/hill_climbing.hpp
@@ -27,11 +27,11 @@ namespace marxan {
     void hill_climbing(int puno, int spno, const vector<spustuff>& pu, const vector<sconnections>& connections,
         vector<sspecies>& spec, const vector<spu>& SM, vector<spu_out>& SM_out, vector<int>& R, double cm,
         scost& reserve, double costthresh, double tpf1, double tpf2,
-        int clumptype,  int irun, int iterations, string savename, stringstream& logBuffer, rng_engine& rngEngine);
+        int clumptype,  int irun, long long iterations, string savename, stringstream& logBuffer, rng_engine& rngEngine);
     
     //consider two steps in a time, move if we found two steps which generates better solution
     void hill_climbing_two_steps(int puno, int spno, const vector<spustuff>& pu, const vector<sconnections>& connections,
         vector<sspecies>& spec, const vector<spu>& SM, vector<spu_out>& SM_out, vector<int>& R, double cm,
         scost& reserve, double costthresh, double tpf1, double tpf2,
-        int clumptype,  int irun, int iterations, string savename, stringstream& logBuffer, rng_engine& rngEngine);
+        int clumptype,  int irun, long long iterations, string savename, stringstream& logBuffer, rng_engine& rngEngine);
 } // namespace marxan

--- a/marxan.cpp
+++ b/marxan.cpp
@@ -866,7 +866,7 @@ int main(int argc, char* argv[]) {
     if (argc > 1)
     {
         // handle the program options
-        marxan::handleOptions(argc, argv, sInputFileName);
+        marxan::handleOptions(argc, argv, sInputFileName, marxan::marxanIsSecondary);
     }
 
     try

--- a/marxan.cpp
+++ b/marxan.cpp
@@ -690,7 +690,7 @@ namespace marxan {
 
             anneal_global.Tlen = anneal_global.iterations / anneal_global.Titns;
             displayProgress2("  Temperature length %ld \n", anneal_global.Tlen);
-            displayProgress2("  iterations %ld, repeats %ld \n", anneal_global.iterations, repeats);
+            displayProgress2("  iterations %lld, repeats %ld \n", anneal_global.iterations, repeats);
         } // Annealing Preprocessing. Should be moved to SetAnnealingOptions
 
         if (fnames.savepenalty)

--- a/marxan.cpp
+++ b/marxan.cpp
@@ -129,8 +129,8 @@ namespace marxan {
             stringstream appendLogBuffer; // stores the trace file log
             stringstream runConsoleOutput; // stores the console message for the run. This is needed for more organized printing output due to multithreading.
             sanneal anneal = anneal_global;
-            scost reserve = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-            scost change = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+            scost reserve;
+            scost change;
 
             vector<int> R(puno);
 

--- a/marxan.cpp
+++ b/marxan.cpp
@@ -241,6 +241,8 @@ namespace marxan {
                     appendLogBuffer << "after hill climbing run " << run_id << endl;
                 }
 
+                cout<<"\nHeuristic on = " <<runoptions.HeuristicOn<<" type " << heurotype << "\n"; 
+
                 if (runoptions.HeuristicOn)
                 {
                     appendLogBuffer << "before Heuristics run " << run_id << endl;
@@ -248,7 +250,7 @@ namespace marxan {
                     Heuristics(spno, puno, pu, connections, R, cm, spec, SMGlobal, SM_out, reserve,
                         costthresh, tpf1, tpf2, heurotype, clumptype, appendLogBuffer, rngEngine);
 
-                    if (verbosity > 1 && runoptions.ItImpOn)
+                    if (verbosity > 1)
                     {
                         computeReserveValue(puno, spno, R, pu, connections, SMGlobal, SM_out, cm, spec, aggexist, reserve, clumptype, appendLogBuffer);
                         runConsoleOutput << "Run " << run_id << "  Heuristic: " << displayValueForPUs(puno, spno, R, reserve, spec, misslevel).str();
@@ -812,7 +814,7 @@ namespace marxan {
 
 
     // handle command line parameters for the marxan executable
-    void handleOptions(int argc, char* argv[], string sInputFileName)
+    void handleOptions(int argc, char* argv[], string& sInputFileName)
     {
         if (argc > 4)
         {  // if more than one commandline argument then exit

--- a/marxan.cpp
+++ b/marxan.cpp
@@ -814,7 +814,7 @@ namespace marxan {
 
 
     // handle command line parameters for the marxan executable
-    void handleOptions(int argc, char* argv[], string& sInputFileName)
+    void handleOptions(int argc, char* argv[], string& sInputFileName, int& marxanIsSecondary)
     {
         if (argc > 4)
         {  // if more than one commandline argument then exit

--- a/options.hpp
+++ b/options.hpp
@@ -46,7 +46,7 @@ namespace marxan {
             //repace last comma with "and" 
             auto pos = res.find_last_of(',');
             if(pos != string::npos)
-                res.replace(pos, pos+1, " and");
+                res.replace(pos, 1, " and");
             return res;
         }
 

--- a/output.cpp
+++ b/output.cpp
@@ -789,7 +789,7 @@ namespace marxan {
 
         if (runoptions.ThermalAnnealingOn)
         {
-            fprintf(fp, "Number of iterations %ld\n", anneal.iterations);
+            fprintf(fp, "Number of iterations %lld\n", anneal.iterations);
             if (anneal.Tinit >= 0)
             {
                 fprintf(fp, "Initial temperature %.2f\n", anneal.Tinit);

--- a/quantum_annealing.cpp
+++ b/quantum_annealing.cpp
@@ -271,7 +271,8 @@ namespace marxan {
         long int repeats, int irun, string savename, double misslevel,
         int aggexist, double costthresh, double tpf1, double tpf2, int clumptype, sanneal& anneal, rng_engine& rngEngine)
     {
-        long int itime, i, j, itemp = 0, snapcount, ichanges = 0, iGoodChange;
+        long long itime;
+        long int  i, j, itemp = 0, snapcount, ichanges = 0, iGoodChange;
         long int iRowCounter, iRowLimit, iFluctuationCount;
         double rFluctuationMagnitude, rThreshold, rThresholdMultiplier,
             rAcceptanceProbability;
@@ -279,7 +280,8 @@ namespace marxan {
         FILE* fp = nullptr, * ttfp = nullptr, * Rfp = nullptr;
         string writename, sDecayType;
         vector<int> PUChosen;
-        long int iTests = 0, iIterations;
+        long int iTests = 0;
+        long long iIterations;
         uniform_real_distribution<double> float_range(0.0, 1.0);
 
         if (iQADECAYTYPE == 0)
@@ -287,7 +289,7 @@ namespace marxan {
         else
             sDecayType = "SIGMOIDAL";
 
-        appendTraceFile("quantumAnnealing start iterations %ld decay type %s proportion %f decay A %f decay B %f acceptance probability %f saveannealingtrace %i\n",
+        appendTraceFile("quantumAnnealing start iterations %lld decay type %s proportion %f decay A %f decay B %f acceptance probability %f saveannealingtrace %i\n",
             anneal.iterations, sDecayType.c_str(), rQAPROP, rQADECAY, rQADECAYB, rQAACCPR, fnames.saveannealingtrace);
         if (verbosity > 4)
         {
@@ -416,7 +418,7 @@ namespace marxan {
                 }
 
                 if (verbosity > 4)
-                    fprintf(fp, "%li,%li,%li,%f,%f,%f,%f,%f\n",
+                    fprintf(fp, "%lli,%li,%li,%f,%f,%f,%f,%f\n",
                         itime, itemp, iGoodChange, change.total, change.cost, change.connection, change.penalty, anneal.temp);
 
                 if (fnames.saveannealingtrace)
@@ -427,9 +429,9 @@ namespace marxan {
 
                     if (iRowCounter == 1)
                     {
-                        fprintf(Rfp, "%li", itime);
+                        fprintf(Rfp, "%lli", itime);
 
-                        fprintf(ttfp, "%li,%f,%li,%f,%i,%f,%f,%f\n",
+                        fprintf(ttfp, "%lli,%f,%li,%f,%i,%f,%f,%f\n",
                             itime, costthresh, iGoodChange, reserve.total,
                             reserve.pus, reserve.cost, reserve.connection, reserve.penalty);
                         if (fProb1D == 1)

--- a/thermal_annealing.cpp
+++ b/thermal_annealing.cpp
@@ -43,8 +43,8 @@ namespace marxan {
         long int ipu, imode, iOldR;
         double deltamin = 0, deltamax = 0;
         double localdelta = 1E-10;
-        scost change = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-        scost reserve = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+        scost change;
+        scost reserve;
 
 #ifdef DEBUGTRACEFILE
         FILE* fp = nullptr;
@@ -165,7 +165,7 @@ namespace marxan {
         long int repeats, int irun, string savename, double misslevel,
         int aggexist, double costthresh, double tpf1, double tpf2, int clumptype, sanneal& anneal, stringstream& logBuffer, rng_engine& rngEngine)
     {
-        scost change = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+        scost change;
         long long itime = 0; 
         long int ipu = -1, i, itemp, snapcount = 0, ichanges = 0, iPreviousR, iGoodChange = 0;
         long int iRowCounter, iRowLimit;

--- a/thermal_annealing.cpp
+++ b/thermal_annealing.cpp
@@ -39,7 +39,8 @@ namespace marxan {
         const vector<spu>& SM, vector<spu_out>& SM_out, double cm, sanneal& anneal, int aggexist,
         vector<int>& R, double prop, int clumptype, int irun, stringstream& logBuffer, rng_engine& rngEngine)
     {
-        long int i, ipu, imode, iOldR;
+        long long i;
+        long int ipu, imode, iOldR;
         double deltamin = 0, deltamax = 0;
         double localdelta = 1E-10;
         scost change = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
@@ -165,7 +166,8 @@ namespace marxan {
         int aggexist, double costthresh, double tpf1, double tpf2, int clumptype, sanneal& anneal, stringstream& logBuffer, rng_engine& rngEngine)
     {
         scost change = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-        long int itime = 0, ipu = -1, i, itemp, snapcount = 0, ichanges = 0, iPreviousR, iGoodChange = 0;
+        long long itime = 0; 
+        long int ipu = -1, i, itemp, snapcount = 0, ichanges = 0, iPreviousR, iGoodChange = 0;
         long int iRowCounter, iRowLimit;
         double rTemperature, rThreshold, rThresholdMultiplier;
         string tempname1, tempname2, sRun = to_string(irun), paddedRun = utils::intToPaddedString(irun, 5);


### PR DESCRIPTION
Fixed  bug with input file parameter ignored.

Extended limits of possible amount of iterations, (need to use long long, int and long int ~ 2 billions in x64)

Improved results of two step hill climbing by looking first on selected pu units. (In test datasets. , amount of final selected units is only fraction, about 0.2.  Not looking at pair add two pu unit improved score in practical situations where amount of allowed iterations below needed for fine search) .